### PR TITLE
saving file without BOM as syncdata does not like BOM

### DIFF
--- a/sources/cfc-seed.json
+++ b/sources/cfc-seed.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "model": "auth.user",
     "pk": 1,


### PR DESCRIPTION
Converted `sources/cfc-seed.json` from `UTF-8 with BOM` to `UTF-8` to fix https://github.com/Call-for-Code-for-Racial-Justice/Legit-Info/issues/68.