### PR TITLE
Use bootstrap for form to enable better error/validation messages

### DIFF
--- a/cfc_app/templates/search.html
+++ b/cfc_app/templates/search.html
@@ -15,9 +15,10 @@ ul {
 }
 </style>
 
-    <form action="{% url 'cfc_app:search' %}" method='post'>
+    <form action="{% url 'cfc_app:search' %}" method='post' novalidate>
         {% csrf_token %}
-        {{ form.as_p }}
+        {% bootstrap_form form %}
+        {% bootstrap_form_errors form %}
     <div class="row mx-auto">
       <button id="submit" name="submit" class="btn btn-lg btn-success mx-auto"
           value="1">Search Legislation</button>


### PR DESCRIPTION
Contributes to #97 

## What did you do?
Loaded the bootstrap package reference, updated how the form is built (using the bootstrap_form instead of form.as_p), added style overrides for text and border color as they don't meet WCAG guidelines for contrast.

## Why did you do it?
Tooltips and popovers often provide poor experiences for users who rely on assistive devices. The Bootstrap validation for form fields displays a message directly with the form field.
 
## How have you tested it?
Yes

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [X] N/A

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
