### PR TITLE
Add css to override Bootstrap colors for WCAG compliance

### DIFF
--- a/cfc_app/templates/base.html
+++ b/cfc_app/templates/base.html
@@ -14,7 +14,9 @@
 
 {% bootstrap_css %}
 {% bootstrap_javascript jquery='full' %}
+{% load static %}
 
+<link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap-overrides.css' %}"/>
 <style>
 .bg-company-red {
     background-color: #6F2F2C !important;

--- a/static/css/bootstrap-overrides.css
+++ b/static/css/bootstrap-overrides.css
@@ -3,8 +3,8 @@
 }
 .navbar-dark .navbar-nav .nav-link:focus, 
 .navbar-dark .navbar-nav .nav-link:hover {
-    background-color: #A74C44;
-    color: white;
+    color: white; 
+    outline: 2px solid white;
 }
 .btn-primary {
     background-color: #0063CC;

--- a/static/css/bootstrap-overrides.css
+++ b/static/css/bootstrap-overrides.css
@@ -26,7 +26,10 @@
     background-color: #128091;
     border-color: #128091;
 }
-
+.btn-info:not(:disabled):hover, .btn-info:not(:disabled):focus {
+    background-color: #0F6875;
+    border-color: #0F6875;
+}
 .invalid-feedback {
     color: #9C1C26;
 }

--- a/static/css/bootstrap-overrides.css
+++ b/static/css/bootstrap-overrides.css
@@ -1,0 +1,35 @@
+.navbar-dark .navbar-nav .nav-link {
+    color: white;
+}
+.navbar-dark .navbar-nav .nav-link:focus, 
+.navbar-dark .navbar-nav .nav-link:hover {
+    background-color: #A74C44;
+    color: white;
+}
+.btn-primary {
+    background-color: #0063CC;
+    border-color: #0063CC;
+}
+.btn-primary:not(:disabled):hover, .btn-primary:not(:disabled):focus {
+    background-color: #004FA3;
+    border-color: #004FA3;
+}
+.btn-success {
+    background-color: #208337;
+    border-color: #208337;
+}
+.btn-success:not(:disabled):hover, .btn-success:not(:disabled):focus {
+    background-color: #186329;
+    border-color: #186329;
+}
+.btn-info {
+    background-color: #128091;
+    border-color: #128091;
+}
+
+.invalid-feedback {
+    color: #9C1C26;
+}
+.form-control.is-invalid, .was-validated .form-control:invalid {
+    border-color: #9C1C26;
+}


### PR DESCRIPTION
Fixes #117 

## What did you do?
Added overrides for success, info, and primary buttons for Bootstrap, as well as color changes for the main menu
## Why did you do it?
In order to get color for buttons and navigation to meeting WCAG 2.0 AA guidelines for contrast
## How have you tested it?
I have run both the aXe extension, as well as WAVE and manually run the new color combinations through WebAIM's color contrast checker
## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [X] N/A

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
