### PR TITLE
Fixed hadolint error on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38
+FROM registry.access.redhat.com/ubi8/python-38:1-71.1634036286
 
 WORKDIR /opt/app-root/src
 
@@ -13,8 +13,8 @@ ENV LC_ALL=C.UTF-8 \
     PYTHONFAULTHANDLER=1
 
 # see issue https://github.com/pypa/pipenv/issues/4220 for pipenv version
-RUN pip install --upgrade pip && \
-    pip install pipenv==2018.11.26 && \
+RUN pip install --no-cache-dir --upgrade pip==21.3.1 && \
+    pip install --no-cache-dir pipenv==2018.11.26 && \
     pipenv install --system --dev
 
 EXPOSE 8080


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <ulidder@us.ibm.com>

Contributes to #120 and #122 

@arianahl @tonypearson can you please review? Thank you.

## What did you do?
Hadolint gives three warnings for Dockerfile and blocks #122:
- Dockerfile:1 DL3006 warning: Always tag the version of an image explicitly
  - tagged base image with latest explicit tag: `registry.access.redhat.com/ubi8/python-38:1-71.1634036286`
- Dockerfile:16 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
  - Added version for pip. I got this from `pip freeze` inside the docker container, so we know it works
- Dockerfile:16 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
  - Added `--no-cache-dir` to pip install
  
## Why did you do it?
Same as above

## How have you tested it?
Yes. Tested locally with docker.

## Were docs updated if needed?

- [x ] No
- [ ] Yes
- [ ] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue
