### PR TITLE
Add skip link to nav, add styles to support, add id to main

### DIFF
--- a/cfc_app/templates/base.html
+++ b/cfc_app/templates/base.html
@@ -14,7 +14,6 @@
 
 {% bootstrap_css %}
 {% bootstrap_javascript jquery='full' %}
-{% load static %}
 
 <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap-overrides.css' %}"/>
 <style>
@@ -22,6 +21,19 @@
     background-color: #6F2F2C !important;
     color: #ffffff;
     }
+.skip-link {
+    position: absolute;
+    transform: translateY(-160%);
+    transition: transform 0.2s ease-in-out;
+    color: white; 
+}
+.skip-link:focus {
+    padding: 0.8rem .5rem;
+    transform: translateY(0%);
+    left: 30%;
+    outline: 2px solid white;
+}
+
 </style>
 
 </head>
@@ -29,7 +41,7 @@
 <body>
 
 <nav class="navbar navbar-expand-md navbar-dark bg-company-red mb-5 border">
-
+<a href="#main-content" class="skip-link">Skip to main</a>
 <a class="navbar-brand" href="{% url 'cfc_app:index' %}">
            {% app_name request %}
 </a>
@@ -83,7 +95,7 @@
 </div>
 </nav>
 
-<main role="main" class="container">
+<main role="main" class="container" id="main-content">
 
 <div class="m-0 mb-4 pl-5 pr-5 pt-2 pb-2 text-center bg-company-red">
        {% block page_header %}{% endblock page_header %}


### PR DESCRIPTION
Signed-off-by: Danielle Mayabb <dmmayabb@gmail.com>

Contributes to #135 

## What did you do?
I added a skip link to the main navigation with attendant styles. As seen below, this is how the link will appear when someone hits tab once landing on a page in Legit-Info. The link is only visible when it receives focus so will not impede sighted/non-keyboard-using users. Once the link loses focus, it is again hidden, but remains in the tab order for items in the menu. 

![tab-to-skip-link](https://user-images.githubusercontent.com/3666105/144765122-6fe1cb30-f981-42b4-969e-fe1911ae479f.png)
## Why did you do it?
To make sure that we complied with [WCAG Level 2 at 2.4.1 for Bypass Blocks](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html). This will allow folks who use solely a keyboard to navigate to bypass the menu and not have to tab through all the links every time they land on a new page in the site. 
## How have you tested it?
Yes. I have tested on desktop and mobile using a keyboard to make sure that I can hit the link on tab and that clicking/activating link takes me to the main content.
## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [X] N/A

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
