### PR TITLE
Update getting started steps to include steps for fixing pystache installation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ on how to deploy the project on a live system.
 
 `pipenv install`
 
+---
+
+**Note:** An error might appear in the installation of `pystache==0.5.4` (because `pystache` uses `2to3` for installation, which is not supported in `setuptools>58`).
+
+To fix this, run `pipenv run pip install setuptools==57.5.0`.
+
+Then run `pipenv install` again. The intallation of the packages should now complete without errors.
+
+---
+
 4. Use the following command if you already have installed the dependencies and want to activate the virtual environment only.
 
 `pipenv shell`


### PR DESCRIPTION

Signed-off-by: Shubham Saxena <s.shubham.work@gmail.com>

Does not contribute to any existing issue.

## What did you do?
Updated the Getting Started steps on the README.md file to include a note which highlights the steps to fix a failure of installation of one of the packages (pystache).

## Why did you do it?
Installation of `pystache` was failing because `setuptools` stopped supporting `2to3` version 58 onwards. Since `pipenv` doesn't currently support pinning the version of `setuptools`, the fix has to be applied manually. Moreover, since `pipenv` virtual environment creation installs (close to) the latest version of `setuptools`, this issue is likely to be faced by everyone following the Getting Started steps from this point onwards.

## How have you tested it?
Tested the steps on my own local machine (twice).

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [x] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue
