### PR TITLE
Fix Hash.find_item_name

### DIFF
--- a/cfc_app/models.py
+++ b/cfc_app/models.py
@@ -285,8 +285,8 @@ class Hash(models.Model):
     def find_item_name(name, mode=settings.FOB_METHOD):
         """ get item if exists, None if not """
 
-        record = Hash.objects.get(item_name=name,
-                                     fob_method=mode)
+        record = Hash.objects.filter(item_name=name,
+                                     fob_method=mode).first()
         return record
 
 


### PR DESCRIPTION
Contributes to #144

## What did you do?

Fix the function Hash.find_item_name to return None when object does not exist

## Why did you do it?

Earlier, Hash.find_item_name used to throw an error if object did not exist. This caused the cron jobs to fail.

## How have you tested it?

Ran the cron jobs locally - working fine now

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [X] N/A

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
