### PR TITLE
Fix hardcoded directories in cron jobs; add env variable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ on how to deploy the project on a live system.
 
 ### Running the cron jobs
 
-Legit Info uses cron jobs to routinely fetch legislation data from Legiscan. The cron job can be run using the `weekly.sh` (for stage 1; development) shell script. However,
-in order to run the cron jobs, you need to set the following environment variables first:
+Legit Info uses cron jobs to routinely fetch legislation data from Legiscan, documented in [CRON.md](docs/CRON.md). The cron jobs can be run using the `weekly.sh`
+(for stage 1; development) shell script. However, in order to run the cron jobs, you need to set the following environment variables first:
 
 `FOB_STORAGE`
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ on how to deploy the project on a live system.
 
 `./stage1 runserver localhost:3000`
 
+### Running the cron jobs
+
+Legit Info uses cron jobs to routinely fetch legislation data from Legiscan. The cron job can be run using the `weekly.sh` (for stage 1; development) shell script. However,
+in order to run the cron jobs, you need to set the following environment variables first:
+
+`FOB_STORAGE`
+
+`LEGISCAN_API_KEY`
+
+Set the `FOB_STORAGE` environment variable to the path to the folder on your local machine where you want the data to be stored.
+
+Set the `LEGISCAN_API_KEY` environment variable to the Legiscan API key you obtain from their website. Legiscan has a free tier
+that allows a few thousand queries per month, which should suffice for development purposes.
+
 ### States of Deployment
 
 ![Deployment Stages](docs/Deployment_Stages.png)

--- a/cron1
+++ b/cron1
@@ -32,4 +32,9 @@ if [[ -z "${LEGISCAN_API_KEY}" ]]; then
 fi
 
 echo $parms
+
+# change working directory to the one in which script resides
+scriptPath=`dirname $0`
+cd $scriptPath
+
 pipenv run python manage.py $parms

--- a/cron1
+++ b/cron1
@@ -18,5 +18,18 @@ tables="auth.user users.profile cfc_app.criteria cfc_app.impact cfc_app.location
 outfile="--output sources/cfc-seed.json"
 parms="dumpdata $tables $outfile"
 fi
+
+if [[ -z "${FOB_STORAGE}" ]]; then
+        echo "Error: FOB_STORAGE environment variable not found"
+        echo "Please set the FOB_STORAGE environment variable before running the script."
+        exit 0
+fi
+
+if [[ -z "${LEGISCAN_API_KEY}" ]]; then
+        echo "Error: LEGISCAN_API_KEY environment variable not found"
+        echo "Please set the LEGISCAN_API_KEY environment variable before running the script."
+        exit 0
+fi
+
 echo $parms
-cd ~/Develop/Legit-Info && pipenv run python manage.py $parms
+pipenv run python manage.py $parms

--- a/cron2
+++ b/cron2
@@ -17,5 +17,18 @@ tables="auth.user users.profile cfc_app.criteria cfc_app.impact cfc_app.location
 outfile="--output sources/cfc-seed.json"
 parms="dumpdata $tables $outfile"
 fi
+
+if [[ -z "${FOB_STORAGE}" ]]; then
+        echo "Error: FOB_STORAGE environment variable not found"
+        echo "Please set the FOB_STORAGE environment variable before running the script."
+        exit 0
+fi
+
+if [[ -z "${LEGISCAN_API_KEY}" ]]; then
+        echo "Error: LEGISCAN_API_KEY environment variable not found"
+        echo "Please set the LEGISCAN_API_KEY environment variable before running the script."
+        exit 0
+fi
+
 echo $parms
-cd ~/Develop/Legit-Info && pipenv run python manage.py $parms
+pipenv run python manage.py $parms

--- a/cron2
+++ b/cron2
@@ -31,4 +31,9 @@ if [[ -z "${LEGISCAN_API_KEY}" ]]; then
 fi
 
 echo $parms
+
+# change working directory to the one in which script resides
+scriptPath=`dirname $0`
+cd $scriptPath
+
 pipenv run python manage.py $parms

--- a/weekly.sh
+++ b/weekly.sh
@@ -15,6 +15,10 @@ if [[ -z "${LEGISCAN_API_KEY}" ]]; then
 	exit 0
 fi
 
+# change working directory to the one in which script resides
+scriptPath=`dirname $0`
+cd $scriptPath
+
 ./cron1 get_datasets --api
 ./cron1 extract_files --api --skip --limit 0
 ./cron1 analyze_text --api --skip --compare --limit 0

--- a/weekly.sh
+++ b/weekly.sh
@@ -3,6 +3,18 @@
 # Use cron1 for SQLite3, and cron2 for PostgreSQL.
 # --limit 0 means "unlimited" and will work on all files found
 
-/app/cron1 get_datasets --api
-/app/cron1 extract_files --api --skip --limit 0
-/app/cron1 analyze_text --api --skip --compare --limit 0
+if [[ -z "${FOB_STORAGE}" ]]; then
+	echo "Error: FOB_STORAGE environment variable not found"
+	echo "Please set the FOB_STORAGE environment variable before running the script."
+	exit 0
+fi
+
+if [[ -z "${LEGISCAN_API_KEY}" ]]; then
+	echo "Error: LEGISCAN_API_KEY environment variable not found"
+	echo "Please set the LEGISCAN_API_KEY environment variable before running the script."
+	exit 0
+fi
+
+./cron1 get_datasets --api
+./cron1 extract_files --api --skip --limit 0
+./cron1 analyze_text --api --skip --compare --limit 0


### PR DESCRIPTION
Contributes to #161 

## What did you do?

Converted the absolute directories set in the cron jobs into relative directories.
Added a check in the cron jobs to verify that the required environment variables have been set before running.

## Why did you do it?

Absolute directories hardcoded into the cron jobs made it impossible for users on different machines to run the cron jobs.
Two environment variables are required for running the cron jobs, but there is no error/warning displayed when a user attempts to run the jobs without setting them.

## How have you tested it?

Tested it by running the cron jobs on my local machine; working fine.

## Were docs updated if needed?

- [ ] No
- [X] Yes
- [ ] N/A

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
