### PR TITLE
Increase days for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: ':wave: Hi! This issue has been marked stale due to inactivity. If no further activity occurs, it will automatically be closed.'
@@ -18,5 +18,5 @@ jobs:
         stale-issue-label: 'stale'
         exempt-issue-label: 'keep-open'
         stale-pr-label: 'stale'
-        days-before-stale: 30
-        days-before-close: 7
+        days-before-stale: 90
+        days-before-close: 30


### PR DESCRIPTION
Signed-off-by: Upkar Lidder [ulidder@us.ibm.com](mailto:ulidder@us.ibm.com)

Changed to 90 days before marking stale and another 30 days before closing PRs and issues.

